### PR TITLE
[Bug] Guard for undefined input in watch and mounted methods

### DIFF
--- a/src/components/BCHDExplorer.vue
+++ b/src/components/BCHDExplorer.vue
@@ -98,7 +98,10 @@ export default {
 
     const params = this.$route.params
     const input = params.address || params.blockHash || params.txId
-    this.searchBCHD(input)
+
+    if (input != undefined) {
+      this.searchBCHD(input)
+    }
   },
   watch: {
     $route(to) {
@@ -107,7 +110,10 @@ export default {
 
       this.input = ""
       const input = to.params.address || to.params.blockHash || to.params.txId
-      this.searchBCHD(input)
+
+      if (input != undefined) {
+        this.searchBCHD(input)
+      }
     }
   },
   methods: {

--- a/tests/unit/BCHDExplorer.spec.js
+++ b/tests/unit/BCHDExplorer.spec.js
@@ -23,7 +23,7 @@ describe('BCHDExplorer.vue', () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = new VueRouter()
-    
+
     const wrapper = mount(BCHDExplorer, {
       localVue,
       router,
@@ -45,7 +45,7 @@ describe('BCHDExplorer.vue', () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = new VueRouter()
-    
+
     const wrapper = mount(BCHDExplorer, {
       localVue,
       router,
@@ -67,7 +67,7 @@ describe('BCHDExplorer.vue', () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = new VueRouter()
-    
+
     const wrapper = mount(BCHDExplorer, {
       localVue,
       router,
@@ -89,7 +89,7 @@ describe('BCHDExplorer.vue', () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = new VueRouter()
-    
+
     const wrapper = mount(BCHDExplorer, {
       localVue,
       router,


### PR DESCRIPTION
There was a slight regression when the routing code was added. When the root route is hit, and no params are in the path it was trying to search for `undefined`. Then due to that search it would show `No address, transaction or block hash/height found.` in the results.

This just adds a guard on that case, and now doesn't show the error when you first load the main page.